### PR TITLE
Defer serialize

### DIFF
--- a/lib/formalist/index.js
+++ b/lib/formalist/index.js
@@ -28,6 +28,12 @@ var _formalistSerializeReact = require('formalist-serialize-react');
 
 var _formalistSerializeReact2 = _interopRequireDefault(_formalistSerializeReact);
 
+var _lodash = require('lodash.debounce');
+
+var _lodash2 = _interopRequireDefault(_lodash);
+
+require('ric');
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -49,8 +55,12 @@ var FormWrapper = function (_Component) {
     var _this = _possibleConstructorReturn(this, Object.getPrototypeOf(FormWrapper).call(this, props));
 
     var form = _this.props.form;
+
+    var formState = form.store.getState();
+    var serialized = _this.serializeForm(formState);
     _this.state = {
-      formState: form.store.getState()
+      formState: formState,
+      serialized: serialized
     };
     return _this;
   }
@@ -61,11 +71,29 @@ var FormWrapper = function (_Component) {
       var _this2 = this;
 
       var form = this.props.form;
-      form.store.subscribe(function () {
-        _this2.setState({
-          formState: form.store.getState()
+
+      form.store.subscribe(
+      // Debounce the reducer
+      (0, _lodash2.default)(function () {
+        // Wait for an idle callback to trigger the serialized render
+        // as it’s less important and more expensive
+        window.requestUserIdle(function () {
+          var formState = form.store.getState();
+          var serialized = _this2.serializeForm(formState);
+          _this2.setState({
+            formState: formState,
+            serialized: serialized
+          });
         });
-      });
+      }, 250));
+    }
+  }, {
+    key: 'serializeForm',
+    value: function serializeForm(formState) {
+      var prefix = this.props.prefix;
+
+      formState = formState || this.props.form.store.getState();
+      return (0, _formalistSerializeReact2.default)(formState.toJS(), { prefix: prefix });
     }
   }, {
     key: 'shouldComponentUpdate',
@@ -75,16 +103,14 @@ var FormWrapper = function (_Component) {
   }, {
     key: 'render',
     value: function render() {
-      var _props = this.props;
-      var form = _props.form;
-      var prefix = _props.prefix;
-      var formState = this.state.formState;
+      var form = this.props.form;
+      var serialized = this.state.serialized;
 
       return _react2.default.createElement(
         'div',
         null,
         form.render(),
-        (0, _formalistSerializeReact2.default)(formState, { prefix: prefix })
+        serialized
       );
     }
   }]);

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,6 +7,10 @@ exports.default = roneo;
 
 require('turbolinks');
 
+var _domready = require('domready');
+
+var _domready2 = _interopRequireDefault(_domready);
+
 var _viewloader = require('viewloader');
 
 var _viewloader2 = _interopRequireDefault(_viewloader);
@@ -29,9 +33,14 @@ function removeNavOpenClasses() {
 
 
 function roneo() {
-  // DOMContentLoaded equivalent with Turbolinks
-  document.addEventListener('turbolinks:load', function onTurboLinksLoad() {
+  (0, _domready2.default)(function onDomready() {
     _viewloader2.default.execute(_views2.default);
+  });
+  // DOMContentLoaded equivalent with Turbolinks
+  document.addEventListener('turbolinks:render', function onTurboLinksLoad() {
+    _viewloader2.default.execute(_views2.default);
+    var pageEl = document.querySelector('.page');
+    pageEl.classList.remove('page--inactive');
   });
 
   // Hide nav when navigating

--- a/package.json
+++ b/package.json
@@ -44,7 +44,9 @@
     "formalist-serialize-react": "icelab/formalist-serialize-react",
     "formalist-standard-react": "icelab/formalist-standard-react",
     "immutable": "3.7.6",
+    "lodash.debounce": "4.0.7",
     "metaquery": "1.2.5",
+    "ric": "1.3.0",
     "turbolinks": "5.0.0-beta4",
     "viewloader": "1.1.1"
   },

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "tape": "^4.2.2"
   },
   "dependencies": {
+    "domready": "^1.0.8",
     "es5-shim": "4.5.7",
     "es6-shim": "0.35.0",
     "fastclick": "1.0.6",

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import 'turbolinks'
+import domready from 'domready'
 import viewloader from 'viewloader'
 
 // Components
@@ -15,9 +16,14 @@ function removeNavOpenClasses () {
 }
 
 export default function roneo () {
-  // DOMContentLoaded equivalent with Turbolinks
-  document.addEventListener('turbolinks:load', function onTurboLinksLoad () {
+  domready(function onDomready () {
     viewloader.execute(views)
+  })
+  // DOMContentLoaded equivalent with Turbolinks
+  document.addEventListener('turbolinks:render', function onTurboLinksLoad () {
+    viewloader.execute(views)
+    let pageEl = document.querySelector('.page')
+    pageEl.classList.remove('page--inactive')
   })
 
   // Hide nav when navigating


### PR DESCRIPTION
Debounce and defer the form serialisation into an idle callback, and ensure we’re calling our views on `DOMContentLoaded` too.