### PR TITLE
Allow form intercept/submission cancellation

### DIFF
--- a/lib/formalist/index.js
+++ b/lib/formalist/index.js
@@ -101,9 +101,18 @@ var FormWrapper = function (_Component) {
           self.setState({
             serialized: serialized
           }, function () {
-            // After state is set, remove our listener and submit the form again
-            parentForm.removeEventListener('submit', onParentSubmit);
-            parentForm.submit();
+            // Create and dispatch a custom event that is cancelable
+            var postSerializationEvent = new window.CustomEvent('postserialization', {
+              detail: {
+                serialized: serialized,
+                originalEvent: e
+              },
+              cancelable: true
+            });
+            var succeeded = parentForm.dispatchEvent(postSerializationEvent);
+            if (succeeded) {
+              parentForm.submit();
+            }
           });
         });
         // Enable/disable the form

--- a/src/formalist/index.js
+++ b/src/formalist/index.js
@@ -56,9 +56,18 @@ class FormWrapper extends Component {
         self.setState({
           serialized,
         }, () => {
-          // After state is set, remove our listener and submit the form again
-          parentForm.removeEventListener('submit', onParentSubmit)
-          parentForm.submit()
+          // Create and dispatch a custom event that is cancelable
+          const postSerializationEvent = new window.CustomEvent('postserialization', {
+            detail: {
+              serialized,
+              originalEvent: e,
+            },
+            cancelable: true,
+          })
+          const succeeded = parentForm.dispatchEvent(postSerializationEvent)
+          if (succeeded) {
+            parentForm.submit()
+          }
         })
       })
       // Enable/disable the form


### PR DESCRIPTION
`formalist` components now dispatch a `postserialization` event to their `parentForm` that allows for cancellation through `event.preventDefault()`. If the event is cancelled, then the form submission won’t complete.

This is necessary because of the double-submission pass we to do _ensure_ that the form is serialised properly before allowing it to be submitted to the server.