### PR TITLE
Fix obscured breadcrumb anchor on widescreens

### DIFF
--- a/lib/nav/index.css
+++ b/lib/nav/index.css
@@ -35,6 +35,9 @@
     transition-duration: var(--navOpenDuration);
     width: 2rem;
   }
+  .breakpoint-widescreen .nav:after {
+    display: none;
+  }
   .breakpoint-widescreen .nav {
     padding-top: var(--headerHeightDesktop);
   }

--- a/src/nav/index.css
+++ b/src/nav/index.css
@@ -35,6 +35,9 @@
     transition-duration: var(--navOpenDuration);
     width: 2rem;
   }
+  .breakpoint-widescreen .nav:after {
+    display: none;
+  }
   .breakpoint-widescreen .nav {
     padding-top: var(--headerHeightDesktop);
   }


### PR DESCRIPTION
This PR fixes an issue where the (hidden) nav dividing shadow partially blocks the breadcrumb/action anchor target:

![image](https://user-images.githubusercontent.com/1016074/50752134-04bc6180-12a1-11e9-8fd4-dcc0cf5ff2eb.png)
