### PR TITLE
Remove `metaquery` dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,6 @@ There are multiple parts to Roneo.
 
 The general structure of the admin should conform to the content in [`./html/shell.html`](). There’s also a [slim](http://slim-lang.com) version at [`./html/shell.slim`]().
 
-### Breakpoints
-
-We use [metaQuery](https://github.com/benschwarz/metaquery) for gaining access to media queries in JavaScript and CSS. The admin expects the breakpoints in [`./html/breakpoints.html`]() to be included in the page.
-
 ### JavaScript
 
 General JavaScript for the admin shell. This will handle any document `onready` bindings for setup. Simple import and call it:

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ roneo()
 
 There are also two separate components for bootstrapping the page. These are intended to be inlined in the `<head>` and just inside the `</body>` respectively.
 
-`inline-header` sets up metaQuery and asynchronously loads some custom fonts for the admin from Google Fonts. It also checks a `localStorage` value to see if the fonts _should_ already be cached, for example on subsequent page loads, and adds a `.fonts-loaded` class to the document:
+`inline-header` asynchronously loads some custom fonts for the admin from Google Fonts. It also checks a `localStorage` value to see if the fonts _should_ already be cached, for example on subsequent page loads, and adds a `.fonts-loaded` class to the document:
 
 ```js
 import inlineHeader from 'roneo/lib/inline-header'

--- a/html/breakpoints.html
+++ b/html/breakpoints.html
@@ -1,7 +1,0 @@
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="breakpoint" content="widescreen" media="(min-width: 1400px)">
-<meta name="breakpoint" content="desktop" media="(min-width: 1024px) and (max-width: 1399px)">
-<meta name="breakpoint" content="tablet-wide" media="(min-width: 768px) and (max-width: 1023px)">
-<meta name="breakpoint" content="tablet" media="(min-width: 640px) and (max-width: 767px)">
-<meta name="breakpoint" content="phone" media="(max-width: 639px)">
-<meta name="breakpoint" content="retina" media="(-webkit-min-device-pixel-ratio: 2), only screen and (   min--moz-device-pixel-ratio: 2), only screen and (-o-min-device-pixel-ratio: 2/1), only screen and (min-device-pixel-ratio: 2), only screen and (min-resolution: 192dpi), only screen and (min-resolution: 2dppx)">

--- a/html/breakpoints.slim
+++ b/html/breakpoints.slim
@@ -1,7 +1,0 @@
-meta name="viewport" content="width=device-width, initial-scale=1.0"
-meta name="breakpoint" content="widescreen" media="(min-width: 1400px)"
-meta name="breakpoint" content="desktop" media="(min-width: 1024px) and (max-width: 1399px)"
-meta name="breakpoint" content="tablet-wide" media="(min-width: 768px) and (max-width: 1023px)"
-meta name="breakpoint" content="tablet" media="(min-width: 640px) and (max-width: 767px)"
-meta name="breakpoint" content="phone" media="(max-width: 639px)"
-meta name="breakpoint" content="retina" media="(-webkit-min-device-pixel-ratio: 2), only screen and (   min--moz-device-pixel-ratio: 2), only screen and (-o-min-device-pixel-ratio: 2/1), only screen and (min-device-pixel-ratio: 2), only screen and (min-resolution: 192dpi), only screen and (min-resolution: 2dppx)"

--- a/html/minimal-shell.html
+++ b/html/minimal-shell.html
@@ -3,12 +3,6 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="breakpoint" content="widescreen" media="(min-width: 1400px)">
-    <meta name="breakpoint" content="desktop" media="(min-width: 1024px) and (max-width: 1399px)">
-    <meta name="breakpoint" content="tablet-wide" media="(min-width: 768px) and (max-width: 1023px)">
-    <meta name="breakpoint" content="tablet" media="(min-width: 640px) and (max-width: 767px)">
-    <meta name="breakpoint" content="phone" media="(max-width: 639px)">
-    <meta name="breakpoint" content="retina" media="(-webkit-min-device-pixel-ratio: 2), only screen and (   min--moz-device-pixel-ratio: 2), only screen and (-o-min-device-pixel-ratio: 2/1), only screen and (min-device-pixel-ratio: 2), only screen and (min-resolution: 192dpi), only screen and (min-resolution: 2dppx)">
     <!-- Inlined JavaScript -->
     <script>
       ... inline header

--- a/html/minimal-shell.slim
+++ b/html/minimal-shell.slim
@@ -1,7 +1,7 @@
 html lang="en"
   head
     meta charset="utf-8"
-    == page.breakpoints
+    meta name="viewport" content="width=device-width, initial-scale=1.0"
     / Inlined JavaScript
     script
       == page.assets.read("inline-admin-boot-header.js")

--- a/html/shell.html
+++ b/html/shell.html
@@ -3,12 +3,6 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="breakpoint" content="widescreen" media="(min-width: 1400px)">
-    <meta name="breakpoint" content="desktop" media="(min-width: 1024px) and (max-width: 1399px)">
-    <meta name="breakpoint" content="tablet-wide" media="(min-width: 768px) and (max-width: 1023px)">
-    <meta name="breakpoint" content="tablet" media="(min-width: 640px) and (max-width: 767px)">
-    <meta name="breakpoint" content="phone" media="(max-width: 639px)">
-    <meta name="breakpoint" content="retina" media="(-webkit-min-device-pixel-ratio: 2), only screen and (   min--moz-device-pixel-ratio: 2), only screen and (-o-min-device-pixel-ratio: 2/1), only screen and (min-device-pixel-ratio: 2), only screen and (min-resolution: 192dpi), only screen and (min-resolution: 2dppx)">
     <!-- Inlined JavaScript -->
     <script>
       ... inline header

--- a/html/shell.slim
+++ b/html/shell.slim
@@ -1,7 +1,7 @@
 html lang="en"
   head
     meta charset="utf-8"
-    == page.breakpoints
+    meta name="viewport" content="width=device-width, initial-scale=1.0"
     / Inlined JavaScript
     script
       == page.assets.read("inline-admin-boot-header.js")

--- a/lib/base/index.css
+++ b/lib/base/index.css
@@ -5,11 +5,15 @@
 html {
   font-size: 62.5%;
 }
-html.breakpoint-tablet {
-  font-size: 56.25%;
+@media (min-width: 640px) and (max-width: 767px) {
+  html {
+    font-size: 56.25%;
+  }
 }
-html.breakpoint-phone {
-  font-size: 50%;
+@media (max-width: 639px) {
+  html {
+    font-size: 50%;
+  }
 }
 
 body {
@@ -23,6 +27,8 @@ body {
 .fonts-loaded body {
   font-family: var(--fontPrimary);
 }
-.breakpoint-widescreen body {
-  display: flex;
+@media (min-width: 1400px) {
+  body {
+    display: flex;
+  }
 }

--- a/lib/disable-input-zoom/index.js
+++ b/lib/disable-input-zoom/index.js
@@ -13,6 +13,8 @@ const phoneBreakpoint = window.matchMedia("(max-width: 639px)");
 phoneBreakpoint.addEventListener("change", function (e) {
   if (e.matches) {
     allowDisable = true;
+  } else {
+    allowDisable = false;
   }
 });
 

--- a/lib/disable-input-zoom/index.js
+++ b/lib/disable-input-zoom/index.js
@@ -9,11 +9,10 @@ var allowDisable = false;
 /**
  * Enable/disable the zoom disabling function. Meta, I know.
  */
-if (window.metaQuery) {
-  window.metaQuery.onBreakpointChange('phone', function (matches) {
-    allowDisable = matches;
-  });
-}
+const phoneBreakpoint = window.matchMedia("(max-width: 639px)");
+phoneBreakpoint.addEventListener("change", function () {
+  allowDisable = matches;
+});
 
 /**
  * Toggle scaling using the viewport meta directive

--- a/lib/disable-input-zoom/index.js
+++ b/lib/disable-input-zoom/index.js
@@ -10,8 +10,10 @@ var allowDisable = false;
  * Enable/disable the zoom disabling function. Meta, I know.
  */
 const phoneBreakpoint = window.matchMedia("(max-width: 639px)");
-phoneBreakpoint.addEventListener("change", function () {
-  allowDisable = matches;
+phoneBreakpoint.addEventListener("change", function (e) {
+  if (e.matches) {
+    allowDisable = matches;
+  }
 });
 
 /**

--- a/lib/disable-input-zoom/index.js
+++ b/lib/disable-input-zoom/index.js
@@ -12,7 +12,7 @@ var allowDisable = false;
 const phoneBreakpoint = window.matchMedia("(max-width: 639px)");
 phoneBreakpoint.addEventListener("change", function (e) {
   if (e.matches) {
-    allowDisable = matches;
+    allowDisable = true;
   }
 });
 

--- a/lib/header/index.css
+++ b/lib/header/index.css
@@ -42,12 +42,14 @@
       text-decoration: underline;
     }
 
-    .breakpoint-phone .header {
-      background-color: var(--colorGreyHint);
-      height: var(--headerHeightPhone);
-      padding-left: var(--spacingMedium);
-      padding-right: var(--spacingMedium);
-      position: fixed;
+    @media (max-width: 639px) {
+      .header {
+        background-color: var(--colorGreyHint);
+        height: var(--headerHeightPhone);
+        padding-left: var(--spacingMedium);
+        padding-right: var(--spacingMedium);
+        position: fixed;
+      }
     }
 
 .header-nav {

--- a/lib/index.js
+++ b/lib/index.js
@@ -63,8 +63,10 @@ function roneo(views) {
    * Make adjustments based on breakpoints
    */
   const widescreenBreakpoint = window.matchMedia("(min-width: 1400px)");
-  widescreenBreakpoint.addEventListener("change", function () {
-    removeNavOpenClasses();
+  widescreenBreakpoint.addEventListener("change", function (e) {
+    if (e.matches) {
+      removeNavOpenClasses();
+    }
   });
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -60,16 +60,12 @@ function roneo(views) {
   });
 
   /**
-   * Make adjustments based on metaQuery breakpoints
-   * Assumes that metaQuery is an object on window (because it should be inlined)
+   * Make adjustments based on breakpoints
    */
-  if (window.metaQuery) {
-    window.metaQuery.onBreakpointChange('widescreen', function onBreakpointChangeWidescreen(matches) {
-      if (matches) {
-        removeNavOpenClasses();
-      }
-    });
-  }
+  const widescreenBreakpoint = window.matchMedia("(min-width: 1400px)");
+  widescreenBreakpoint.addEventListener("change", function () {
+    removeNavOpenClasses();
+  });
 }
 
 // Additional exports

--- a/lib/inline-header/index.js
+++ b/lib/inline-header/index.js
@@ -9,22 +9,12 @@ var _fontsCached = require('../fonts-cached');
 
 var _fontsCached2 = _interopRequireDefault(_fontsCached);
 
-var _metaquery = require('metaquery');
-
-var _metaquery2 = _interopRequireDefault(_metaquery);
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
-window.metaQuery = _metaquery2.default;
 
 /**
  * Intended to be inlined and injected in to the <head> of the page
  */
 
-
-/**
- * Expose metaQuery as a global on window
- */
 function inlineHeader() {
   var options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
 

--- a/lib/nav/index.css
+++ b/lib/nav/index.css
@@ -35,11 +35,15 @@
     transition-duration: var(--navOpenDuration);
     width: 2rem;
   }
-  .breakpoint-widescreen .nav:after {
-    display: none;
+  @media (min-width: 1400px) {
+    .nav:after {
+      display: none;
+    }
   }
-  .breakpoint-widescreen .nav {
-    padding-top: var(--headerHeightDesktop);
+  @media (min-width: 1400px) {
+    .nav {
+      padding-top: var(--headerHeightDesktop);
+    }
   }
   .nav.nav-open {
     transform: translate3d(0, 0, 0);
@@ -47,11 +51,13 @@
     .nav.nav-open:after {
       opacity: 1;
     }
-  .breakpoint-widescreen .nav {
-    flex: 1;
-    position: relative;
-    transform: none;
-    overflow: visible;
+  @media (min-width: 1400px) {
+    .nav {
+      flex: 1;
+      position: relative;
+      transform: none;
+      overflow: visible;
+    }
   }
 
   .nav__content {

--- a/lib/page/index.css
+++ b/lib/page/index.css
@@ -20,17 +20,21 @@
   .page.nav-open {
     transform: translate3d(var(--navWidth), 0, 0);
   }
-  .breakpoint-widescreen .page {
-    flex: 3;
-    padding-left: 0;
+  @media (min-width: 1400px) {
+    .page {
+      flex: 3;
+      padding-left: 0;
+    }
   }
-  .breakpoint-phone .page {
-    overflow-x: hidden;
-    overflow-y: scroll;
-    -webkit-overflow-scrolling: touch;
-    padding-top: var(--headerHeightPhone);
-    padding-right: var(--spacingMedium);
-    padding-left: var(--spacingMedium);
+  @media (max-width: 639px) {
+    .page {
+      overflow-x: hidden;
+      overflow-y: scroll;
+      -webkit-overflow-scrolling: touch;
+      padding-top: var(--headerHeightPhone);
+      padding-right: var(--spacingMedium);
+      padding-left: var(--spacingMedium);
+    }
   }
 
 .page__contents {
@@ -39,8 +43,10 @@
   max-width: 144rem;
   padding-top: var(--spacingLarge);
 }
-  .breakpoint-phone .page__contents {
-    padding-top: var(--spacingMedium);
+  @media (max-width: 639px) {
+    .page__contents {
+      padding-top: var(--spacingMedium);
+    }
   }
 
 

--- a/lib/panel/index.css
+++ b/lib/panel/index.css
@@ -10,13 +10,17 @@
   margin-top: var(--spacingXLarge);
   padding: var(--spacingXLarge);
 }
-  .breakpoint-tablet .panel,
-  .breakpoint-phone .panel {
-    flex-direction: column;
+  @media (min-width: 640px) and (max-width: 767px) {
+    .panel {
+      flex-direction: column;
+    }
   }
-  .breakpoint-phone .panel {
-    margin-top: var(--spacingMedium);
-    padding: var(--spacingLarge);
+  @media (max-width: 639px) {
+    .panel {
+      flex-direction: column;
+      margin-top: var(--spacingMedium);
+      padding: var(--spacingLarge);
+    }
   }
 
 .tabs + .panel {
@@ -32,16 +36,18 @@
   margin-left: var(--spacingXLarge);
   flex: 2;
 }
-  .breakpoint-tablet .panel__secondary,
-  .breakpoint-phone .panel__secondary {
-    margin-top: var(--spacingXLarge);
-    margin-left: 0;
-    width: 100%;
+  @media (max-width: 767px) {
+    .panel__secondary {
+      margin-top: var(--spacingXLarge);
+      margin-left: 0;
+      width: 100%;
+    }
   }
-  .breakpoint-tablet .panel__secondary[class*="fb-order-1"],
-  .breakpoint-phone .panel__secondary[class*="fb-order-1"] {
-    margin-bottom: var(--spacingXLarge);
-    margin-top: auto;
+  @media (max-width: 767px) {
+    .panel__secondary[class*="fb-order-1"] {
+      margin-bottom: var(--spacingXLarge);
+      margin-top: auto;
+    }
   }
 
 .panel__left {
@@ -59,8 +65,9 @@
     margin-left: var(--spacingXLarge);
     margin-right: var(--spacingXLarge);
   }
-  .breakpoint-tablet .panel__thirds,
-  .breakpoint-phone .panel__thirds {
-    margin-left: 0;
-    margin-right: 0;
+  @media (max-width: 767px) {
+    .panel__thirds {
+      margin-left: 0;
+      margin-right: 0;
+    }
   }

--- a/lib/tables/index.css
+++ b/lib/tables/index.css
@@ -5,11 +5,15 @@
   margin-bottom: var(--spacingXSmall);
   max-width: 100%;
 }
-  .table--overflow,
-  .breakpoint-tablet .table,
-  .breakpoint-phone .table {
+  .table--overflow {
     -webkit-overflow-scrolling: touch;
     overflow-x: scroll;
+  }
+  @media (max-width: 767px) {
+    .table {
+      -webkit-overflow-scrolling: touch;
+      overflow-x: scroll;
+    }
   }
   .table table {
     width: 100%;

--- a/lib/traits/layout.css
+++ b/lib/traits/layout.css
@@ -54,38 +54,118 @@
   align-items: center;
 }
 
-.fb-order-1,
-.breakpoint-widescreen .fb-order-1--widescreen,
-.breakpoint-desktop .fb-order-1--desktop,
-.breakpoint-tablet-wide .fb-order-1--tablet-wide,
-.breakpoint-tablet .fb-order-1--tablet,
-.breakpoint-phone .fb-order-1--phone {
+.fb-order-1 {
   order: 1;
 }
+@media (min-width: 1400px) {
+  .fb-order-1--widescreen {
+    order: 1;
+  }
+}
+@media (min-width: 1024px) and (max-width: 1399px) {
+  .fb-order-1--desktop {
+    order: 1;
+  }
+}
+@media (min-width: 768px) and (max-width: 1023px) {
+  .fb-order-1--tablet-wide {
+    order: 1;
+  }
+}
+@media (min-width: 640px) and (max-width: 767px) {
+  .fb-order-1--tablet {
+    order: 1;
+  }
+}
+@media (max-width: 639px) {
+  .fb-order-1--phone {
+    order: 1;
+  }
+}
 
-.fb-order-2,
-.breakpoint-widescreen .fb-order-2--widescreen,
-.breakpoint-desktop .fb-order-2--desktop,
-.breakpoint-tablet-wide .fb-order-2--tablet-wide,
-.breakpoint-tablet .fb-order-2--tablet,
-.breakpoint-phone .fb-order-2--phone {
+.fb-order-2 {
   order: 2;
 }
-
-.fb-order-3,
-.breakpoint-widescreen .fb-order-3--widescreen,
-.breakpoint-desktop .fb-order-3--desktop,
-.breakpoint-tablet-wide .fb-order-3--tablet-wide,
-.breakpoint-tablet .fb-order-3--tablet,
-.breakpoint-phone .fb-order-3--phone {
-  order: 3;
+@media (min-width: 1400px) {
+  .fb-order-2--widescreen {
+    order: 2;
+  }
+}
+@media (min-width: 1024px) and (max-width: 1399px) {
+  .fb-order-2--desktop {
+    order: 2;
+  }
+}
+@media (min-width: 768px) and (max-width: 1023px) {
+  .fb-order-2--tablet-wide {
+    order: 2;
+  }
+}
+@media (min-width: 640px) and (max-width: 767px) {
+  .fb-order-2--tablet {
+    order: 2;
+  }
+}
+@media (max-width: 639px) {
+  .fb-order-2--phone {
+    order: 2;
+  }
 }
 
-.fb-order-4,
-.breakpoint-widescreen .fb-order-4--widescreen,
-.breakpoint-desktop .fb-order-4--desktop,
-.breakpoint-tablet-wide .fb-order-4--tablet-wide,
-.breakpoint-tablet .fb-order-4--tablet,
-.breakpoint-phone .fb-order-4--phone {
+.fb-order-3 {
+  order: 3;
+}
+@media (min-width: 1400px) {
+  .fb-order-3--widescreen {
+    order: 3;
+  }
+}
+@media (min-width: 1024px) and (max-width: 1399px) {
+  .fb-order-3--desktop {
+    order: 3;
+  }
+}
+@media (min-width: 768px) and (max-width: 1023px) {
+  .fb-order-3--tablet-wide {
+    order: 3;
+  }
+}
+@media (min-width: 640px) and (max-width: 767px) {
+  .fb-order-3--tablet {
+    order: 3;
+  }
+}
+@media (max-width: 639px) {
+  .fb-order-3--phone {
+    order: 3;
+  }
+}
+
+.fb-order-4 {
   order: 4;
+}
+@media (min-width: 1400px) {
+  .fb-order-4--widescreen {
+    order: 4;
+  }
+}
+@media (min-width: 1024px) and (max-width: 1399px) {
+  .fb-order-4--desktop {
+    order: 4;
+  }
+}
+@media (min-width: 768px) and (max-width: 1023px) {
+  .fb-order-4--tablet-wide {
+    order: 4;
+  }
+}
+@media (min-width: 640px) and (max-width: 767px) {
+  .fb-order-4--tablet {
+    order: 4;
+  }
+}
+@media (max-width: 639px) {
+  .fb-order-4--phone {
+    order: 4;
+  }
 }

--- a/lib/traits/misc.css
+++ b/lib/traits/misc.css
@@ -36,37 +36,111 @@
 
 /* Visibility */
 
-.hide-all,
-.breakpoint-widescreen .hide-widescreen,
-.breakpoint-desktop .hide-desktop,
-.breakpoint-tablet-wide .hide-tablet-wide,
-.breakpoint-tablet .hide-tablet,
-.breakpoint-phone .hide-phone {
+.hide-all {
   display: none;
 }
-
-.breakpoint-widescreen .show-widescreen,
-.breakpoint-desktop .show-desktop,
-.breakpoint-tablet-wide .show-tablet-wide,
-.breakpoint-tablet .show-tablet,
-.breakpoint-phone .show-phone {
-  display: block;
+@media (min-width: 1400px) {
+  .hide-widescreen {
+    display: none;
+  }
+}
+@media (min-width: 1024px) and (max-width: 1399px) {
+  .hide-desktop {
+    display: none;
+  }
+}
+@media (min-width: 768px) and (max-width: 1023px) {
+  .hide-tablet-wide {
+    display: none;
+  }
+}
+@media (min-width: 640px) and (max-width: 767px) {
+  .hide-tablet {
+    display: none;
+  }
+}
+@media (max-width: 639px) {
+  .hide-phone {
+    display: none;
+  }
 }
 
-.breakpoint-widescreen .show-widescreen--i,
-.breakpoint-desktop .show-desktop--i,
-.breakpoint-tablet-wide .show-tablet-wide--i,
-.breakpoint-tablet .show-tablet--i,
-.breakpoint-phone .show-phone--i {
-  display: inline;
+@media (min-width: 1400px) {
+  .show-widescreen {
+    display: block;
+  }
+}
+@media (min-width: 1024px) and (max-width: 1399px) {
+  .show-desktop {
+    display: block;
+  }
+}
+@media (min-width: 768px) and (max-width: 1023px) {
+  .show-tablet-wide {
+    display: block;
+  }
+}
+@media (min-width: 640px) and (max-width: 767px) {
+  .show-tablet {
+    display: block;
+  }
+}
+@media (max-width: 639px) {
+  .show-phone {
+    display: block;
+  }
 }
 
-.breakpoint-widescreen .show-widescreen--ib,
-.breakpoint-desktop .show-desktop--ib,
-.breakpoint-tablet-wide .show-tablet-wide--ib,
-.breakpoint-tablet .show-tablet--ib,
-.breakpoint-phone .show-phone--ib {
-  display: inline-block;
+@media (min-width: 1400px) {
+  .show-widescreen--i {
+    display: inline;
+  }
+}
+@media (min-width: 1024px) and (max-width: 1399px) {
+  .show-desktop--i {
+    display: inline;
+  }
+}
+@media (min-width: 768px) and (max-width: 1023px) {
+  .show-tablet-wide--i {
+    display: inline;
+  }
+}
+@media (min-width: 640px) and (max-width: 767px) {
+  .show-tablet--i {
+    display: inline;
+  }
+}
+@media (max-width: 639px) {
+  .show-phone--i {
+    display: inline;
+  }
+}
+
+@media (min-width: 1400px) {
+  .show-widescreen--ib {
+    display: inline-block;
+  }
+}
+@media (min-width: 1024px) and (max-width: 1399px) {
+  .show-desktop--ib {
+    display: inline-block;
+  }
+}
+@media (min-width: 768px) and (max-width: 1023px) {
+  .show-tablet-wide--ib {
+    display: inline-block;
+  }
+}
+@media (min-width: 640px) and (max-width: 767px) {
+  .show-tablet--ib {
+    display: inline-block;
+  }
+}
+@media (max-width: 639px) {
+  .show-phone--ib {
+    display: inline-block;
+  }
 }
 
 /*

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "formalist-serialize-react": "^1.0.6",
     "formalist-standard-react": "^4.1.4",
     "immutable": "^3.8.2",
-    "metaquery": "^1.2.5",
     "nodemon": "^1.18.6",
     "prop-types": "^15.6.0",
     "turbolinks": "^5.2.0",

--- a/src/base/index.css
+++ b/src/base/index.css
@@ -5,11 +5,15 @@
 html {
   font-size: 62.5%;
 }
-html.breakpoint-tablet {
-  font-size: 56.25%;
+@media (min-width: 640px) and (max-width: 767px) {
+  html {
+    font-size: 56.25%;
+  }
 }
-html.breakpoint-phone {
-  font-size: 50%;
+@media (max-width: 639px) {
+  html {
+    font-size: 50%;
+  }
 }
 
 body {
@@ -23,6 +27,8 @@ body {
 .fonts-loaded body {
   font-family: var(--fontPrimary);
 }
-.breakpoint-widescreen body {
-  display: flex;
+@media (min-width: 1400px) {
+  body {
+    display: flex;
+  }
 }

--- a/src/disable-input-zoom/index.js
+++ b/src/disable-input-zoom/index.js
@@ -3,11 +3,11 @@ let allowDisable = false
 /**
  * Enable/disable the zoom disabling function. Meta, I know.
  */
-if (window.metaQuery) {
-  window.metaQuery.onBreakpointChange('phone', (matches) => {
-    allowDisable = matches
-  })
-}
+const phoneBreakpoint = window.matchMedia("(max-width: 639px)")
+phoneBreakpoint.addEventListener("change", () => {
+  allowDisable = matches
+})
+
 
 /**
  * Toggle scaling using the viewport meta directive

--- a/src/disable-input-zoom/index.js
+++ b/src/disable-input-zoom/index.js
@@ -6,7 +6,7 @@ let allowDisable = false
 const phoneBreakpoint = window.matchMedia("(max-width: 639px)")
 phoneBreakpoint.addEventListener("change", (e) => {
   if (e.matches) {
-    allowDisable = matches
+    allowDisable = true
   }
 })
 

--- a/src/disable-input-zoom/index.js
+++ b/src/disable-input-zoom/index.js
@@ -7,6 +7,8 @@ const phoneBreakpoint = window.matchMedia("(max-width: 639px)")
 phoneBreakpoint.addEventListener("change", (e) => {
   if (e.matches) {
     allowDisable = true
+  } else {
+    allowDisable = false
   }
 })
 

--- a/src/disable-input-zoom/index.js
+++ b/src/disable-input-zoom/index.js
@@ -4,8 +4,10 @@ let allowDisable = false
  * Enable/disable the zoom disabling function. Meta, I know.
  */
 const phoneBreakpoint = window.matchMedia("(max-width: 639px)")
-phoneBreakpoint.addEventListener("change", () => {
-  allowDisable = matches
+phoneBreakpoint.addEventListener("change", (e) => {
+  if (e.matches) {
+    allowDisable = matches
+  }
 })
 
 

--- a/src/header/index.css
+++ b/src/header/index.css
@@ -42,12 +42,14 @@
       text-decoration: underline;
     }
 
-    .breakpoint-phone .header {
-      background-color: var(--colorGreyHint);
-      height: var(--headerHeightPhone);
-      padding-left: var(--spacingMedium);
-      padding-right: var(--spacingMedium);
-      position: fixed;
+    @media (max-width: 639px) {
+      .header {
+        background-color: var(--colorGreyHint);
+        height: var(--headerHeightPhone);
+        padding-left: var(--spacingMedium);
+        padding-right: var(--spacingMedium);
+        position: fixed;
+      }
     }
 
 .header-nav {

--- a/src/index.js
+++ b/src/index.js
@@ -47,8 +47,10 @@ export default function roneo (views) {
    * Make adjustments based on breakpoints
    */
   const widescreenBreakpoint = window.matchMedia("(min-width: 1400px)")
-  widescreenBreakpoint.addEventListener("change", () => {
-    removeNavOpenClasses()
+  widescreenBreakpoint.addEventListener("change", (e) => {
+    if (e.matches) {
+      removeNavOpenClasses()
+    }
   })
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -44,16 +44,12 @@ export default function roneo (views) {
   })
 
   /**
-   * Make adjustments based on metaQuery breakpoints
-   * Assumes that metaQuery is an object on window (because it should be inlined)
+   * Make adjustments based on breakpoints
    */
-  if (window.metaQuery) {
-    window.metaQuery.onBreakpointChange('widescreen', function onBreakpointChangeWidescreen (matches) {
-      if (matches) {
-        removeNavOpenClasses()
-      }
-    })
-  }
+  const widescreenBreakpoint = window.matchMedia("(min-width: 1400px)")
+  widescreenBreakpoint.addEventListener("change", () => {
+    removeNavOpenClasses()
+  })
 }
 
 // Additional exports

--- a/src/inline-header/index.js
+++ b/src/inline-header/index.js
@@ -1,12 +1,6 @@
 import fontsCached from '../fonts-cached'
 
 /**
- * Expose metaQuery as a global on window
- */
-import metaQuery from 'metaquery'
-window.metaQuery = metaQuery
-
-/**
  * Intended to be inlined and injected in to the <head> of the page
  */
 export default function inlineHeader (options = {}) {

--- a/src/nav/index.css
+++ b/src/nav/index.css
@@ -35,11 +35,15 @@
     transition-duration: var(--navOpenDuration);
     width: 2rem;
   }
-  .breakpoint-widescreen .nav:after {
-    display: none;
+  @media (min-width: 1400px) {
+    .nav:after {
+      display: none;
+    }
   }
-  .breakpoint-widescreen .nav {
-    padding-top: var(--headerHeightDesktop);
+  @media (min-width: 1400px) {
+    .nav {
+      padding-top: var(--headerHeightDesktop);
+    }
   }
   .nav.nav-open {
     transform: translate3d(0, 0, 0);
@@ -47,11 +51,13 @@
     .nav.nav-open:after {
       opacity: 1;
     }
-  .breakpoint-widescreen .nav {
-    flex: 1;
-    position: relative;
-    transform: none;
-    overflow: visible;
+  @media (min-width: 1400px) {
+    .nav {
+      flex: 1;
+      position: relative;
+      transform: none;
+      overflow: visible;
+    }
   }
 
   .nav__content {

--- a/src/page/index.css
+++ b/src/page/index.css
@@ -20,17 +20,21 @@
   .page.nav-open {
     transform: translate3d(var(--navWidth), 0, 0);
   }
-  .breakpoint-widescreen .page {
-    flex: 3;
-    padding-left: 0;
+  @media (min-width: 1400px) {
+    .page {
+      flex: 3;
+      padding-left: 0;
+    }
   }
-  .breakpoint-phone .page {
-    overflow-x: hidden;
-    overflow-y: scroll;
-    -webkit-overflow-scrolling: touch;
-    padding-top: var(--headerHeightPhone);
-    padding-right: var(--spacingMedium);
-    padding-left: var(--spacingMedium);
+  @media (max-width: 639px) {
+    .page {
+      overflow-x: hidden;
+      overflow-y: scroll;
+      -webkit-overflow-scrolling: touch;
+      padding-top: var(--headerHeightPhone);
+      padding-right: var(--spacingMedium);
+      padding-left: var(--spacingMedium);
+    }
   }
 
 .page__contents {
@@ -39,8 +43,10 @@
   max-width: 144rem;
   padding-top: var(--spacingLarge);
 }
-  .breakpoint-phone .page__contents {
-    padding-top: var(--spacingMedium);
+  @media (max-width: 639px) {
+    .page__contents {
+      padding-top: var(--spacingMedium);
+    }
   }
 
 

--- a/src/panel/index.css
+++ b/src/panel/index.css
@@ -10,13 +10,17 @@
   margin-top: var(--spacingXLarge);
   padding: var(--spacingXLarge);
 }
-  .breakpoint-tablet .panel,
-  .breakpoint-phone .panel {
-    flex-direction: column;
+  @media (min-width: 640px) and (max-width: 767px) {
+    .panel {
+      flex-direction: column;
+    }
   }
-  .breakpoint-phone .panel {
-    margin-top: var(--spacingMedium);
-    padding: var(--spacingLarge);
+  @media (max-width: 639px) {
+    .panel {
+      flex-direction: column;
+      margin-top: var(--spacingMedium);
+      padding: var(--spacingLarge);
+    }
   }
 
 .tabs + .panel {
@@ -32,16 +36,18 @@
   margin-left: var(--spacingXLarge);
   flex: 2;
 }
-  .breakpoint-tablet .panel__secondary,
-  .breakpoint-phone .panel__secondary {
-    margin-top: var(--spacingXLarge);
-    margin-left: 0;
-    width: 100%;
+  @media (max-width: 767px) {
+    .panel__secondary {
+      margin-top: var(--spacingXLarge);
+      margin-left: 0;
+      width: 100%;
+    }
   }
-  .breakpoint-tablet .panel__secondary[class*="fb-order-1"],
-  .breakpoint-phone .panel__secondary[class*="fb-order-1"] {
-    margin-bottom: var(--spacingXLarge);
-    margin-top: auto;
+  @media (max-width: 767px) {
+    .panel__secondary[class*="fb-order-1"] {
+      margin-bottom: var(--spacingXLarge);
+      margin-top: auto;
+    }
   }
 
 .panel__left {
@@ -59,8 +65,9 @@
     margin-left: var(--spacingXLarge);
     margin-right: var(--spacingXLarge);
   }
-  .breakpoint-tablet .panel__thirds,
-  .breakpoint-phone .panel__thirds {
-    margin-left: 0;
-    margin-right: 0;
+  @media (max-width: 767px) {
+    .panel__thirds {
+      margin-left: 0;
+      margin-right: 0;
+    }
   }

--- a/src/tables/index.css
+++ b/src/tables/index.css
@@ -5,11 +5,15 @@
   margin-bottom: var(--spacingXSmall);
   max-width: 100%;
 }
-  .table--overflow,
-  .breakpoint-tablet .table,
-  .breakpoint-phone .table {
+  .table--overflow {
     -webkit-overflow-scrolling: touch;
     overflow-x: scroll;
+  }
+  @media (max-width: 767px) {
+    .table {
+      -webkit-overflow-scrolling: touch;
+      overflow-x: scroll;
+    }
   }
   .table table {
     width: 100%;

--- a/src/traits/layout.css
+++ b/src/traits/layout.css
@@ -54,38 +54,118 @@
   align-items: center;
 }
 
-.fb-order-1,
-.breakpoint-widescreen .fb-order-1--widescreen,
-.breakpoint-desktop .fb-order-1--desktop,
-.breakpoint-tablet-wide .fb-order-1--tablet-wide,
-.breakpoint-tablet .fb-order-1--tablet,
-.breakpoint-phone .fb-order-1--phone {
+.fb-order-1 {
   order: 1;
 }
+@media (min-width: 1400px) {
+  .fb-order-1--widescreen {
+    order: 1;
+  }
+}
+@media (min-width: 1024px) and (max-width: 1399px) {
+  .fb-order-1--desktop {
+    order: 1;
+  }
+}
+@media (min-width: 768px) and (max-width: 1023px) {
+  .fb-order-1--tablet-wide {
+    order: 1;
+  }
+}
+@media (min-width: 640px) and (max-width: 767px) {
+  .fb-order-1--tablet {
+    order: 1;
+  }
+}
+@media (max-width: 639px) {
+  .fb-order-1--phone {
+    order: 1;
+  }
+}
 
-.fb-order-2,
-.breakpoint-widescreen .fb-order-2--widescreen,
-.breakpoint-desktop .fb-order-2--desktop,
-.breakpoint-tablet-wide .fb-order-2--tablet-wide,
-.breakpoint-tablet .fb-order-2--tablet,
-.breakpoint-phone .fb-order-2--phone {
+.fb-order-2 {
   order: 2;
 }
-
-.fb-order-3,
-.breakpoint-widescreen .fb-order-3--widescreen,
-.breakpoint-desktop .fb-order-3--desktop,
-.breakpoint-tablet-wide .fb-order-3--tablet-wide,
-.breakpoint-tablet .fb-order-3--tablet,
-.breakpoint-phone .fb-order-3--phone {
-  order: 3;
+@media (min-width: 1400px) {
+  .fb-order-2--widescreen {
+    order: 2;
+  }
+}
+@media (min-width: 1024px) and (max-width: 1399px) {
+  .fb-order-2--desktop {
+    order: 2;
+  }
+}
+@media (min-width: 768px) and (max-width: 1023px) {
+  .fb-order-2--tablet-wide {
+    order: 2;
+  }
+}
+@media (min-width: 640px) and (max-width: 767px) {
+  .fb-order-2--tablet {
+    order: 2;
+  }
+}
+@media (max-width: 639px) {
+  .fb-order-2--phone {
+    order: 2;
+  }
 }
 
-.fb-order-4,
-.breakpoint-widescreen .fb-order-4--widescreen,
-.breakpoint-desktop .fb-order-4--desktop,
-.breakpoint-tablet-wide .fb-order-4--tablet-wide,
-.breakpoint-tablet .fb-order-4--tablet,
-.breakpoint-phone .fb-order-4--phone {
+.fb-order-3 {
+  order: 3;
+}
+@media (min-width: 1400px) {
+  .fb-order-3--widescreen {
+    order: 3;
+  }
+}
+@media (min-width: 1024px) and (max-width: 1399px) {
+  .fb-order-3--desktop {
+    order: 3;
+  }
+}
+@media (min-width: 768px) and (max-width: 1023px) {
+  .fb-order-3--tablet-wide {
+    order: 3;
+  }
+}
+@media (min-width: 640px) and (max-width: 767px) {
+  .fb-order-3--tablet {
+    order: 3;
+  }
+}
+@media (max-width: 639px) {
+  .fb-order-3--phone {
+    order: 3;
+  }
+}
+
+.fb-order-4 {
   order: 4;
+}
+@media (min-width: 1400px) {
+  .fb-order-4--widescreen {
+    order: 4;
+  }
+}
+@media (min-width: 1024px) and (max-width: 1399px) {
+  .fb-order-4--desktop {
+    order: 4;
+  }
+}
+@media (min-width: 768px) and (max-width: 1023px) {
+  .fb-order-4--tablet-wide {
+    order: 4;
+  }
+}
+@media (min-width: 640px) and (max-width: 767px) {
+  .fb-order-4--tablet {
+    order: 4;
+  }
+}
+@media (max-width: 639px) {
+  .fb-order-4--phone {
+    order: 4;
+  }
 }

--- a/src/traits/misc.css
+++ b/src/traits/misc.css
@@ -36,37 +36,111 @@
 
 /* Visibility */
 
-.hide-all,
-.breakpoint-widescreen .hide-widescreen,
-.breakpoint-desktop .hide-desktop,
-.breakpoint-tablet-wide .hide-tablet-wide,
-.breakpoint-tablet .hide-tablet,
-.breakpoint-phone .hide-phone {
+.hide-all {
   display: none;
 }
-
-.breakpoint-widescreen .show-widescreen,
-.breakpoint-desktop .show-desktop,
-.breakpoint-tablet-wide .show-tablet-wide,
-.breakpoint-tablet .show-tablet,
-.breakpoint-phone .show-phone {
-  display: block;
+@media (min-width: 1400px) {
+  .hide-widescreen {
+    display: none;
+  }
+}
+@media (min-width: 1024px) and (max-width: 1399px) {
+  .hide-desktop {
+    display: none;
+  }
+}
+@media (min-width: 768px) and (max-width: 1023px) {
+  .hide-tablet-wide {
+    display: none;
+  }
+}
+@media (min-width: 640px) and (max-width: 767px) {
+  .hide-tablet {
+    display: none;
+  }
+}
+@media (max-width: 639px) {
+  .hide-phone {
+    display: none;
+  }
 }
 
-.breakpoint-widescreen .show-widescreen--i,
-.breakpoint-desktop .show-desktop--i,
-.breakpoint-tablet-wide .show-tablet-wide--i,
-.breakpoint-tablet .show-tablet--i,
-.breakpoint-phone .show-phone--i {
-  display: inline;
+@media (min-width: 1400px) {
+  .show-widescreen {
+    display: block;
+  }
+}
+@media (min-width: 1024px) and (max-width: 1399px) {
+  .show-desktop {
+    display: block;
+  }
+}
+@media (min-width: 768px) and (max-width: 1023px) {
+  .show-tablet-wide {
+    display: block;
+  }
+}
+@media (min-width: 640px) and (max-width: 767px) {
+  .show-tablet {
+    display: block;
+  }
+}
+@media (max-width: 639px) {
+  .show-phone {
+    display: block;
+  }
 }
 
-.breakpoint-widescreen .show-widescreen--ib,
-.breakpoint-desktop .show-desktop--ib,
-.breakpoint-tablet-wide .show-tablet-wide--ib,
-.breakpoint-tablet .show-tablet--ib,
-.breakpoint-phone .show-phone--ib {
-  display: inline-block;
+@media (min-width: 1400px) {
+  .show-widescreen--i {
+    display: inline;
+  }
+}
+@media (min-width: 1024px) and (max-width: 1399px) {
+  .show-desktop--i {
+    display: inline;
+  }
+}
+@media (min-width: 768px) and (max-width: 1023px) {
+  .show-tablet-wide--i {
+    display: inline;
+  }
+}
+@media (min-width: 640px) and (max-width: 767px) {
+  .show-tablet--i {
+    display: inline;
+  }
+}
+@media (max-width: 639px) {
+  .show-phone--i {
+    display: inline;
+  }
+}
+
+@media (min-width: 1400px) {
+  .show-widescreen--ib {
+    display: inline-block;
+  }
+}
+@media (min-width: 1024px) and (max-width: 1399px) {
+  .show-desktop--ib {
+    display: inline-block;
+  }
+}
+@media (min-width: 768px) and (max-width: 1023px) {
+  .show-tablet-wide--ib {
+    display: inline-block;
+  }
+}
+@media (min-width: 640px) and (max-width: 767px) {
+  .show-tablet--ib {
+    display: inline-block;
+  }
+}
+@media (max-width: 639px) {
+  .show-phone--ib {
+    display: inline-block;
+  }
 }
 
 /*

--- a/yarn.lock
+++ b/yarn.lock
@@ -124,14 +124,6 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
-"argparse@~ 0.1.11":
-  version "0.1.16"
-  resolved "https://registry.yarnpkg.com/argparse/-/argparse-0.1.16.tgz#cfd01e0fbba3d6caed049fbd758d40f65196f57c"
-  integrity sha1-z9AeD7uj1srtBJ+9dY1A9lGW9Xw=
-  dependencies:
-    underscore "~1.7.0"
-    underscore.string "~2.4.0"
-
 arr-diff@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-2.0.0.tgz#8f3b827f955a8bd669697e4a4256ac3ceae356cf"
@@ -208,11 +200,6 @@ async@^1.4.0:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
   integrity sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=
-
-async@~0.1.22:
-  version "0.1.22"
-  resolved "https://registry.yarnpkg.com/async/-/async-0.1.22.tgz#0fc1aaa088a0e3ef0ebe2d8831bab0dcf8845061"
-  integrity sha1-D8GqoIig4+8Ovi2IMbqw3PiEUGE=
 
 asynckit@^0.4.0:
   version "0.4.0"
@@ -1058,11 +1045,6 @@ code-point-at@^1.0.0:
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
   integrity sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
 
-coffee-script@~1.3.3:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/coffee-script/-/coffee-script-1.3.3.tgz#150d6b4cb522894369efed6a2101c20bc7f4a4f4"
-  integrity sha1-FQ1rTLUiiUNp7+1qIQHCC8f0pPQ=
-
 collection-visit@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/collection-visit/-/collection-visit-1.0.0.tgz#4bc0373c164bc3291b4d368c829cf1a80a59dca0"
@@ -1082,11 +1064,6 @@ color-name@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
-
-colors@~0.6.2:
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/colors/-/colors-0.6.2.tgz#2423fe6678ac0c5dae8852e5d0e5be08c997abcc"
-  integrity sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=
 
 combined-stream@1.0.6:
   version "1.0.6"
@@ -1228,11 +1205,6 @@ d@1:
   integrity sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=
   dependencies:
     es5-ext "^0.10.9"
-
-dateformat@1.0.2-1.2.3:
-  version "1.0.2-1.2.3"
-  resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-1.0.2-1.2.3.tgz#b0220c02de98617433b72851cf47de3df2cdbee9"
-  integrity sha1-sCIMAt6YYXQztyhRz0fePfLNvuk=
 
 debug@2, debug@^2.1.1, debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
@@ -1706,11 +1678,6 @@ esprima@^4.0.0:
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
 
-"esprima@~ 1.0.2":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/esprima/-/esprima-1.0.4.tgz#9f557e08fc3b4d26ece9dd34f8fbf476b62585ad"
-  integrity sha1-n1V+CPw7TSbs6d00+Pv0drYlha0=
-
 esrecurse@^4.1.0:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.2.1.tgz#007a3b9fdbc2b3bb87e4879ea19c92fdbd3942cf"
@@ -1736,11 +1703,6 @@ event-emitter@~0.3.5:
     d "1"
     es5-ext "~0.10.14"
 
-eventemitter2@~0.4.13:
-  version "0.4.14"
-  resolved "https://registry.yarnpkg.com/eventemitter2/-/eventemitter2-0.4.14.tgz#8f61b75cde012b2e9eb284d4545583b5643b61ab"
-  integrity sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas=
-
 execa@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/execa/-/execa-0.7.0.tgz#944becd34cc41ee32a63a9faf27ad5a65fc59777"
@@ -1763,11 +1725,6 @@ exit-hook@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/exit-hook/-/exit-hook-1.1.1.tgz#f05ca233b48c05d54fff07765df8507e95c02ff8"
   integrity sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=
-
-exit@~0.1.1:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
-  integrity sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=
 
 expand-brackets@^0.1.4:
   version "0.1.5"
@@ -1929,14 +1886,6 @@ find-with-regex@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/find-with-regex/-/find-with-regex-1.1.3.tgz#d6c6f2debee898d36b6a77e05709b13dd5dc8a26"
   integrity sha512-zkEVQ1H3PIQL/19ADKt1lCQU4QGM3OneiderUcFgn5EgTm/TnoUh7HxPAwP8w/vXxWSLC6KtpbDQpypJ5+majw==
-
-findup-sync@~0.1.2:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/findup-sync/-/findup-sync-0.1.3.tgz#7f3e7a97b82392c653bf06589bd85190e93c3683"
-  integrity sha1-fz56l7gjksZTvwZYm9hRkOk8NoM=
-  dependencies:
-    glob "~3.2.9"
-    lodash "~2.4.1"
 
 flat-cache@^1.2.1:
   version "1.3.0"
@@ -2157,11 +2106,6 @@ get-value@^2.0.3, get-value@^2.0.6:
   resolved "https://registry.yarnpkg.com/get-value/-/get-value-2.0.6.tgz#dc15ca1c672387ca76bd37ac0a395ba2042a2c28"
   integrity sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=
 
-getobject@~0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/getobject/-/getobject-0.1.0.tgz#047a449789fa160d018f5486ed91320b6ec7885c"
-  integrity sha1-BHpEl4n6Fg0Bj1SG7ZEyC27HiFw=
-
 glob-base@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/glob-base/-/glob-base-0.3.0.tgz#dbb164f6221b1c0b1ccf82aea328b497df0ea3c4"
@@ -2196,23 +2140,6 @@ glob@^7.0.3, glob@^7.0.5, glob@^7.1.2, glob@~7.1.2:
     minimatch "^3.0.4"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
-
-glob@~3.1.21:
-  version "3.1.21"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-3.1.21.tgz#d29e0a055dea5138f4d07ed40e8982e83c2066cd"
-  integrity sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=
-  dependencies:
-    graceful-fs "~1.2.0"
-    inherits "1"
-    minimatch "~0.2.11"
-
-glob@~3.2.9:
-  version "3.2.11"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-3.2.11.tgz#4a973f635b9190f715d10987d5c00fd2815ebe3d"
-  integrity sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=
-  dependencies:
-    inherits "2"
-    minimatch "0.3"
 
 global-dirs@^0.1.0:
   version "0.1.1"
@@ -2279,70 +2206,6 @@ graceful-fs@^4.1.4:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
   integrity sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=
-
-graceful-fs@~1.2.0:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-1.2.3.tgz#15a4806a57547cb2d2dbf27f42e89a8c3451b364"
-  integrity sha1-FaSAaldUfLLS2/J/QuiajDRRs2Q=
-
-grunt-legacy-log-utils@~0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/grunt-legacy-log-utils/-/grunt-legacy-log-utils-0.1.1.tgz#c0706b9dd9064e116f36f23fe4e6b048672c0f7e"
-  integrity sha1-wHBrndkGThFvNvI/5OawSGcsD34=
-  dependencies:
-    colors "~0.6.2"
-    lodash "~2.4.1"
-    underscore.string "~2.3.3"
-
-grunt-legacy-log@~0.1.0:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/grunt-legacy-log/-/grunt-legacy-log-0.1.3.tgz#ec29426e803021af59029f87d2f9cd7335a05531"
-  integrity sha1-7ClCboAwIa9ZAp+H0vnNczWgVTE=
-  dependencies:
-    colors "~0.6.2"
-    grunt-legacy-log-utils "~0.1.1"
-    hooker "~0.2.3"
-    lodash "~2.4.1"
-    underscore.string "~2.3.3"
-
-grunt-legacy-util@~0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz#93324884dbf7e37a9ff7c026dff451d94a9e554b"
-  integrity sha1-kzJIhNv343qf98Am3/RR2UqeVUs=
-  dependencies:
-    async "~0.1.22"
-    exit "~0.1.1"
-    getobject "~0.1.0"
-    hooker "~0.2.3"
-    lodash "~0.9.2"
-    underscore.string "~2.2.1"
-    which "~1.0.5"
-
-grunt@~0.4.1:
-  version "0.4.5"
-  resolved "https://registry.yarnpkg.com/grunt/-/grunt-0.4.5.tgz#56937cd5194324adff6d207631832a9d6ba4e7f0"
-  integrity sha1-VpN81RlDJK3/bSB2MYMqnWuk5/A=
-  dependencies:
-    async "~0.1.22"
-    coffee-script "~1.3.3"
-    colors "~0.6.2"
-    dateformat "1.0.2-1.2.3"
-    eventemitter2 "~0.4.13"
-    exit "~0.1.1"
-    findup-sync "~0.1.2"
-    getobject "~0.1.0"
-    glob "~3.1.21"
-    grunt-legacy-log "~0.1.0"
-    grunt-legacy-util "~0.2.0"
-    hooker "~0.2.3"
-    iconv-lite "~0.2.11"
-    js-yaml "~2.0.5"
-    lodash "~0.9.2"
-    minimatch "~0.2.12"
-    nopt "~1.0.10"
-    rimraf "~2.2.8"
-    underscore.string "~2.2.1"
-    which "~1.0.5"
 
 has-ansi@^2.0.0:
   version "2.0.0"
@@ -2417,22 +2280,12 @@ home-or-tmp@^2.0.0:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.1"
 
-hooker@~0.2.3:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/hooker/-/hooker-0.2.3.tgz#b834f723cc4a242aa65963459df6d984c5d3d959"
-  integrity sha1-uDT3I8xKJCqmWWNFnfbZhMXT2Vk=
-
 iconv-lite@^0.4.4, iconv-lite@~0.4.13:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
-
-iconv-lite@~0.2.11:
-  version "0.2.11"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.2.11.tgz#1ce60a3a57864a292d1321ff4609ca4bb965adc8"
-  integrity sha1-HOYKOleGSiktEyH/RgnKS7llrcg=
 
 ignore-by-default@^1.0.1:
   version "1.0.1"
@@ -2478,11 +2331,6 @@ inflight@^1.0.4:
   dependencies:
     once "^1.3.0"
     wrappy "1"
-
-inherits@1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/inherits/-/inherits-1.0.2.tgz#ca4309dadee6b54cc0b8d247e8d7c7a0975bdc9b"
-  integrity sha1-ykMJ2t7mtUzAuNJH6NfHoJdb3Js=
 
 inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.3"
@@ -2865,14 +2713,6 @@ js-yaml@^3.5.1, js-yaml@^3.9.0:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
-js-yaml@~2.0.5:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-2.0.5.tgz#a25ae6509999e97df278c6719da11bd0687743a8"
-  integrity sha1-olrmUJmZ6X3yeMZxnaEb0Gh3Q6g=
-  dependencies:
-    argparse "~ 0.1.11"
-    esprima "~ 1.0.2"
-
 jsesc@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-1.3.0.tgz#46c3fec8c1892b12b0833db9bc7622176dbab34b"
@@ -2991,16 +2831,6 @@ lodash@^4.0.0, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
 
-lodash@~0.9.2:
-  version "0.9.2"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-0.9.2.tgz#8f3499c5245d346d682e5b0d3b40767e09f1a92c"
-  integrity sha1-jzSZxSRdNG1oLlsNO0B2fgnxqSw=
-
-lodash@~2.4.1:
-  version "2.4.2"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-2.4.2.tgz#fadd834b9683073da179b3eae6d9c0d15053f73e"
-  integrity sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=
-
 loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
@@ -3012,11 +2842,6 @@ lowercase-keys@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.1.tgz#6f9e30b47084d971a7c820ff15a6c5167b74c26f"
   integrity sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==
-
-lru-cache@2:
-  version "2.7.3"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-2.7.3.tgz#6d4524e8b955f95d4f5b58851ce21dd72fb4e952"
-  integrity sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=
 
 lru-cache@^4.0.1:
   version "4.1.4"
@@ -3049,13 +2874,6 @@ math-random@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/math-random/-/math-random-1.0.1.tgz#8b3aac588b8a66e4975e3cdea67f7bb329601fac"
   integrity sha1-izqsWIuKZuSXXjzepn97sylgH6w=
-
-metaquery@^1.2.5:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/metaquery/-/metaquery-1.2.5.tgz#2794edfd70ed15d7df1f32c3f82b4b3ae3a0c305"
-  integrity sha1-J5Tt/XDtFdffHzLD+CtLOuOgwwU=
-  dependencies:
-    grunt "~0.4.1"
 
 methods@^1.1.1, methods@~1.1.1:
   version "1.1.2"
@@ -3129,28 +2947,12 @@ min-document@^2.19.0:
   dependencies:
     dom-walk "^0.1.0"
 
-minimatch@0.3:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-0.3.0.tgz#275d8edaac4f1bb3326472089e7949c8394699dd"
-  integrity sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=
-  dependencies:
-    lru-cache "2"
-    sigmund "~1.0.0"
-
 minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
   dependencies:
     brace-expansion "^1.1.7"
-
-minimatch@~0.2.11, minimatch@~0.2.12:
-  version "0.2.14"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-0.2.14.tgz#c74e780574f63c6f9a090e90efbe6ef53a6a756a"
-  integrity sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=
-  dependencies:
-    lru-cache "2"
-    sigmund "~1.0.0"
 
 minimist@0.0.5:
   version "0.0.5"
@@ -3970,11 +3772,6 @@ rimraf@^2.2.8, rimraf@^2.6.1:
   dependencies:
     glob "^7.0.5"
 
-rimraf@~2.2.8:
-  version "2.2.8"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.2.8.tgz#e439be2aaee327321952730f99a8929e4fc50582"
-  integrity sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=
-
 run-async@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-0.1.0.tgz#c8ad4a5e110661e402a7d21b530e009f25f8e389"
@@ -4084,11 +3881,6 @@ shelljs@^0.6.0:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.6.1.tgz#ec6211bed1920442088fe0f70b2837232ed2c8a8"
   integrity sha1-7GIRvtGSBEIIj+D3Cyg3Iy7SyKg=
-
-sigmund@~1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/sigmund/-/sigmund-1.0.1.tgz#3ff21f198cad2175f9f3b781853fd94d0d19b590"
-  integrity sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=
 
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
@@ -4516,26 +4308,6 @@ undefsafe@^2.0.2:
   dependencies:
     debug "^2.2.0"
 
-underscore.string@~2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/underscore.string/-/underscore.string-2.2.1.tgz#d7c0fa2af5d5a1a67f4253daee98132e733f0f19"
-  integrity sha1-18D6KvXVoaZ/QlPa7pgTLnM/Dxk=
-
-underscore.string@~2.3.3:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/underscore.string/-/underscore.string-2.3.3.tgz#71c08bf6b428b1133f37e78fa3a21c82f7329b0d"
-  integrity sha1-ccCL9rQosRM/N+ePo6Icgvcymw0=
-
-underscore.string@~2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/underscore.string/-/underscore.string-2.4.0.tgz#8cdd8fbac4e2d2ea1e7e2e8097c42f442280f85b"
-  integrity sha1-jN2PusTi0uoefi6Al8QvRCKA+Fs=
-
-underscore@~1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.7.0.tgz#6bbaf0877500d36be34ecaa584e0db9fef035209"
-  integrity sha1-a7rwh3UA02vjTsqlhODbn+8DUgk=
-
 union-class-names@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/union-class-names/-/union-class-names-1.0.0.tgz#9259608adacc39094a2b0cfe16c78e6200617847"
@@ -4649,11 +4421,6 @@ which@^1.2.9:
   integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
   dependencies:
     isexe "^2.0.0"
-
-which@~1.0.5:
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/which/-/which-1.0.9.tgz#460c1da0f810103d0321a9b633af9e575e64486f"
-  integrity sha1-RgwdoPgQED0DIam2M6+eV15kSG8=
 
 wide-align@^1.1.0:
   version "1.1.3"


### PR DESCRIPTION
This PR removes the [metaquery](https://github.com/benschwarz/metaquery) dependancy by:

* Replacing breakpoint CSS classes with native `@media` syntax
* Replacing `metaquery` JS functions with native `window.matchMedia()` behaviour
* Removing the library from the inlined header

Doing this to get rid of a bunch of insecure dependancies-of-dependancies 🗑️  (and because this is all doable natively).